### PR TITLE
[DEMO] [WIP] Vehicles collide with flowers

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4355,7 +4355,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         ret.type = veh_coll_bashable;
         terrain_collision_data( p, bash_floor, mass2, part_dens, e );
         ret.target_name = g->m.disp_name( p );
-    } else if( g->m.is_bashable_ter_furn( p, false ) ) {
+    } else if( g->m.is_bashable_ter_furn( p, false ) && g->m.passable_ter_furn( p ) ) {
         // Check special parts that collide even on "flat terrain".
         // Tiny things, like flowers, collide with wheels. // TODO: check VPFLAG_TRACK
         // Don't have to check short here: wheels need frames, those collide with everything.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4430,7 +4430,8 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     float vel2 = 0.0f;
     do {
         smashed = false;
-        // Impulse of vehicle
+        // Impulse and velocity delta calculations
+        // Scalar (non-vector), so divide by 100 and multiply by 99 at iteration end to guarantee exit.
         const float vel1 = coll_velocity / 100.0f;
         // Velocity of car after collision
         const float vel1_a = (mass*vel1 + mass2*vel2 + e*mass2*(vel2 - vel1)) / (mass + mass2);
@@ -4440,13 +4441,14 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         const float E_before = 0.5f * (mass * vel1 * vel1)   + 0.5f * (mass2 * vel2 * vel2);
         const float E_after =  0.5f * (mass * vel1_a*vel1_a) + 0.5f * (mass2 * vel2_a*vel2_a);
         const float d_E = E_before - E_after;
+
         if( d_E <= 0 ) {
             // Deformation energy is signed
             // If it's negative, it means something went wrong
             // But it still does happen sometimes...
             if( fabs(vel1_a) < fabs(vel1) ) {
                 // Lower vehicle's speed to prevent infinite loops
-                coll_velocity = vel1_a * 90;
+                coll_velocity = vel1_a * 99;
             }
             if( fabs(vel2_a) > fabs(vel2) ) {
                 vel2 = vel2_a;
@@ -4550,7 +4552,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             }
         }
 
-        coll_velocity = vel1_a * ( smashed ? 100 : 90 );
+        coll_velocity = vel1_a * ( smashed ? 100 : 99 );
         // Stop processing when sign inverts, not when we reach 0
     } while( !smashed && sgn( coll_velocity ) == vel_sign );
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4350,15 +4350,16 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     } else if( ( bash_floor && g->m.is_bashable_ter_furn( p, true ) ) ||
                // Movecost 2 indicates flat terrain like a floor, no collision there.
                ( g->m.is_bashable_ter_furn( p, false ) && g->m.move_cost_ter_furn( p ) != 2 &&
-                 // Tiny things, like flowers, only collide with wheels (see below).
-                 !g->m.has_flag_ter_or_furn( "TINY", p ) &&
                  // These are bashable, but don't interact with vehicles - exclude them.
-                 !g->m.has_flag_ter_or_furn( "NOCOLLIDE", p ) ) ) {
+                 !g->m.has_flag_ter_or_furn( "NOCOLLIDE", p ) &&
+                 // Tiny things, like flowers, only collide with wheels (see below).
+                 !g->m.has_flag_ter_or_furn( "TINY", p ) ) ) {
         ret.type = veh_coll_bashable;
         terrain_collision_data( p, bash_floor, mass2, part_dens, e );
         ret.target_name = g->m.disp_name( p );
-    } else if( g->m.is_bashable_ter_furn( p, false ) && g->m.passable_ter_furn( p ) &&
-               !g->m.has_flag_ter_or_furn( "NOCOLLIDE", p ) ) {
+    } else if( g->m.is_bashable_ter_furn( p, false ) && !g->m.has_flag_ter_or_furn( "NOCOLLIDE", p ) &&
+               // Do not mask next else-if clause!
+               g->m.passable_ter_furn( p ) ) {
         // Check special parts that collide even on "flat terrain".
         // Don't have to check short: wheels need frames, those collide with everything (above).
         // TODO: it would be nice, though, if wheels collided with wreckage (is short) before frame.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4357,7 +4357,8 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         ret.type = veh_coll_bashable;
         terrain_collision_data( p, bash_floor, mass2, part_dens, e );
         ret.target_name = g->m.disp_name( p );
-    } else if( g->m.is_bashable_ter_furn( p, false ) && g->m.passable_ter_furn( p ) ) {
+    } else if( g->m.is_bashable_ter_furn( p, false ) && g->m.passable_ter_furn( p ) &&
+               !g->m.has_flag_ter_or_furn( "NOCOLLIDE", p ) ) {
         // Check special parts that collide even on "flat terrain".
         // Don't have to check short: wheels need frames, those collide with everything (above).
         // TODO: it would be nice, though, if wheels collided with wreckage (is short) before frame.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4350,18 +4350,25 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     } else if( ( bash_floor && g->m.is_bashable_ter_furn( p, true ) ) ||
                // Movecost 2 indicates flat terrain like a floor, no collision there.
                ( g->m.is_bashable_ter_furn( p, false ) && g->m.move_cost_ter_furn( p ) != 2 &&
-                // Don't collide with tiny things, like flowers, unless we have a wheel in our space.
-                (part_with_feature(ret.part, VPFLAG_WHEEL) >= 0 ||
-                 !g->m.has_flag_ter_or_furn("TINY", p)) &&
-                // Protrusions don't collide with short terrain.
-                // Tiny also doesn't, but it's already excluded unless there's a wheel present.
-                !(part_with_feature(ret.part, "PROTRUSION") >= 0 &&
-                  g->m.has_flag_ter_or_furn("SHORT", p)) &&
-                // These are bashable, but don't interact with vehicles.
-                !g->m.has_flag_ter_or_furn("NOCOLLIDE", p) ) ) {
+                 // These are bashable, but don't interact with vehicles - exclude them.
+                 !g->m.has_flag_ter_or_furn( "NOCOLLIDE", p ) ) ) {
         ret.type = veh_coll_bashable;
         terrain_collision_data( p, bash_floor, mass2, part_dens, e );
         ret.target_name = g->m.disp_name( p );
+    } else if( g->m.is_bashable_ter_furn( p, false ) ) {
+        // Check special parts that collide even on "flat terrain".
+        // Tiny things, like flowers, collide with wheels. // TODO: check VPFLAG_TRACK
+        // Don't have to check short here: wheels need frames, those collide with everything.
+        const int maybe_wheel_part = part_with_feature( ret.part, VPFLAG_WHEEL );
+        if( maybe_wheel_part >= 0 && g->m.has_flag_ter_or_furn( "TINY", p ) ) {
+            // TODO
+        }
+        // Protrusions don't collide with tiny/short furniture, they do otherwise.
+        const int maybe_protruding_part = part_with_feature( ret.part, "PROTRUSION" );
+        if( maybe_protruding_part >= 0 && !( g->m.has_flag_ter_or_furn( "TINY", p ) ||
+                                             g->m.has_flag_ter_or_furn( "SHORT", p ) ) ) {
+            // TODO
+        }
     } else if( g->m.impassable_ter_furn( p ) ||
                ( bash_floor && !g->m.has_flag( TFLAG_NO_FLOOR, p ) ) ) {
         ret.type = veh_coll_other; // not destructible

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4339,22 +4339,12 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         e = 0.30;
         part_dens = 15;
         switch( critter->get_size() ) {
-        case MS_TINY:    // Rodent
-            mass2 = 1;
-            break;
-        case MS_SMALL:   // Half human
-            mass2 = 41;
-            break;
+        case MS_TINY:   mass2 =    1; break; // Rodent
+        case MS_SMALL:  mass2 =   41; break; // Half human
         default:
-        case MS_MEDIUM:  // Human
-            mass2 = 82;
-            break;
-        case MS_LARGE:   // Cow
-            mass2 = 400;
-            break;
-        case MS_HUGE:     // TAAAANK
-            mass2 = 1000;
-            break;
+        case MS_MEDIUM: mass2 =   82; break; // Human
+        case MS_LARGE:  mass2 =  400; break; // Cow
+        case MS_HUGE:   mass2 = 1000; break; // TAAAANK
         }
         ret.target_name = critter->disp_name();
     } else if( ( bash_floor && g->m.is_bashable_ter_furn( p, true ) ) ||

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4359,7 +4359,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         ret.target_name = g->m.disp_name( p );
     } else if( g->m.is_bashable_ter_furn( p, false ) && g->m.passable_ter_furn( p ) ) {
         // Check special parts that collide even on "flat terrain".
-        // Don't have to check short here: wheels need frames, those collide with everything.
+        // Don't have to check short: wheels need frames, those collide with everything (above).
         // TODO: it would be nice, though, if wheels collided with wreckage (is short) before frame.
         // TODO: check VPFLAG_TRACK, too
         int not_frame_part = -1;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4446,9 +4446,10 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             // Deformation energy is signed
             // If it's negative, it means something went wrong
             // But it still does happen sometimes...
+            // @todo: debugmsg?..
             if( fabs(vel1_a) < fabs(vel1) ) {
                 // Lower vehicle's speed to prevent infinite loops
-                coll_velocity = vel1_a * 99;
+                coll_velocity = vel1_a * 80;
             }
             if( fabs(vel2_a) > fabs(vel2) ) {
                 vel2 = vel2_a;
@@ -4552,7 +4553,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             }
         }
 
-        coll_velocity = vel1_a * ( smashed ? 100 : 99 );
+        coll_velocity = vel1_a * ( smashed ? 100 : 97 );
         // Stop processing when sign inverts, not when we reach 0
     } while( !smashed && sgn( coll_velocity ) == vel_sign );
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4358,6 +4358,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         }
         ret.target_name = critter->disp_name();
     } else if( ( bash_floor && g->m.is_bashable_ter_furn( p, true ) ) ||
+               // Movecost 2 indicates flat terrain like a floor, no collision there.
                ( g->m.is_bashable_ter_furn( p, false ) && g->m.move_cost_ter_furn( p ) != 2 &&
                 // Don't collide with tiny things, like flowers, unless we have a wheel in our space.
                 (part_with_feature(ret.part, VPFLAG_WHEEL) >= 0 ||
@@ -4368,7 +4369,6 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
                   g->m.has_flag_ter_or_furn("SHORT", p)) &&
                 // These are bashable, but don't interact with vehicles.
                 !g->m.has_flag_ter_or_furn("NOCOLLIDE", p) ) ) {
-        // Movecost 2 indicates flat terrain like a floor, no collision there.
         ret.type = veh_coll_bashable;
         terrain_collision_data( p, bash_floor, mass2, part_dens, e );
         ret.target_name = g->m.disp_name( p );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4362,19 +4362,24 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         // Don't have to check short here: wheels need frames, those collide with everything.
         // TODO: it would be nice, though, if wheels collided with wreckage (is short) before frame.
         // TODO: check VPFLAG_TRACK, too
+        int not_frame_part = -1;
         const int maybe_wheel_part = part_with_feature( ret.part, VPFLAG_WHEEL );
         if( maybe_wheel_part >= 0 && g->m.has_flag_ter_or_furn( "TINY", p ) ) {
-            ret.part = maybe_wheel_part;
+            not_frame_part = maybe_wheel_part;
         }
         // Protrusions don't collide with tiny/short furniture, they do otherwise.
         const int maybe_protruding_part = part_with_feature( ret.part, "PROTRUSION" );
         if( maybe_protruding_part >= 0 && !( g->m.has_flag_ter_or_furn( "TINY", p ) ||
                                              g->m.has_flag_ter_or_furn( "SHORT", p ) ) ) {
-            ret.part = maybe_protruding_part;
+            not_frame_part = maybe_protruding_part;
         }
-        ret.type = veh_coll_bashable;
-        terrain_collision_data( p, bash_floor, mass2, part_dens, e );
-        ret.target_name = g->m.disp_name( p );
+        // Got a non-frame collision.
+        if( not_frame_part != -1 ) {
+            ret.part = not_frame_part;
+            ret.type = veh_coll_bashable;
+            terrain_collision_data( p, bash_floor, mass2, part_dens, e );
+            ret.target_name = g->m.disp_name( p );
+        }
     } else if( g->m.impassable_ter_furn( p ) ||
                ( bash_floor && !g->m.has_flag( TFLAG_NO_FLOOR, p ) ) ) {
         ret.type = veh_coll_other; // not destructible

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4359,7 +4359,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         ret.target_name = g->m.disp_name( p );
     } else if( g->m.is_bashable_ter_furn( p, false ) && !g->m.has_flag_ter_or_furn( "NOCOLLIDE", p ) &&
                // Do not mask next else-if clause!
-               g->m.passable_ter_furn( p ) ) {
+               g->m.passable_ter_furn( p ) && !bash_floor ) {
         // Check special parts that collide even on "flat terrain".
         // Don't have to check short: wheels need frames, those collide with everything (above).
         // TODO: it would be nice, though, if wheels collided with wreckage (is short) before frame.


### PR DESCRIPTION
Naive ~~implementation~~ fix for [#20017](https://github.com/CleverRaven/Cataclysm-DDA/issues/20017) (Vehicle wheels don't crush flowers).

Note: includes [#19974](https://github.com/CleverRaven/Cataclysm-DDA/pull/19974) (vehicle: more iterations for collision loop (hotfix for APC-vs-shrubbery)). Penalty at low speeds is otherwise excessive.